### PR TITLE
src/sh.c: fix empty line check

### DIFF
--- a/src/sh.c
+++ b/src/sh.c
@@ -223,7 +223,7 @@ void repl (compilerCtx* compiler) {
         char* input = readline(prompt.str);
 
         /*Skip empty strings*/
-        if (input[0] == 0)
+        if (!input || input[0] == 0)
             continue;
 
         else if (!strcmp(input, ":exit"))


### PR DESCRIPTION
readline(3) returns NULL for an empty line when EOF is encountered
before the first character.
